### PR TITLE
A LOT of changes

### DIFF
--- a/draft-thomson-httpbis-alt-svcb.md
+++ b/draft-thomson-httpbis-alt-svcb.md
@@ -45,6 +45,7 @@ author:
 normative:
   HTTP: RFC9110
   ORIGIN: RFC6454
+  SVCB: I-D.ietf-dnsop-svcb-https
 
 informative:
   H2:
@@ -57,7 +58,8 @@ informative:
 
 --- abstract
 
-HTTP alternative services
+HTTP servers deployments that include multiple service endpoints can use
+alternative services to direct clients to use a different service endpoint.
 
 This document obsoletes RFC 7838.
 
@@ -65,22 +67,21 @@ This document obsoletes RFC 7838.
 
 # Introduction
 
-HTTP alternative services provide an HTTP server with a means to direct requests
-from clients to an alternative server instance.  Clients that learn about an
-alternative service can establish a connection to the identified instance, which
-- if successfully established and authenticated - can be used for future
-requests.  This design allows for nearly seamless service continuity in some
-conditions.
+HTTP servers are often comprised of multiple service endpoints.  This can be
+driven by multiple requirements, such as a need to scale by adding multiple
+physical servers, the need to place endpoints in network locations that are
+closer to clients for performance reasons, or the need to support multiple HTTP
+versions, like HTTP/2 {{H2}} or HTTP/3 {{H3}}.
 
-The use cases that might motivate a server to direct future requests to a
-different server instance vary.
+For servers that operate multiple service endpoints, it can be advantageous - or
+even necessary - to have clients make requests to a specific service endpoint.
 
-* Some deployments might seek to direct a client to a server instance that is
+* Some deployments might seek to direct a client to a service endpoint that is
   better able to serve requests for that client.  This might occur if DNS
   resolution of the server name produces the address of a server instance that
   is further from the client.
 
-* Servers that might seek to shed load, perhaps in anticipation of an imminent
+* Servers that might seek to reduce load, perhaps in anticipation of an imminent
   shutdown or maintenance action, might use an alternative service declaration
   to reduce either server load or the number of clients that might be affected.
 
@@ -88,34 +89,50 @@ different server instance vary.
   alternative service declaration to make clients aware of support for the newer
   protocol.
 
-These different use cases can sometimes create awkward trade-offs for
-deployments of alternative services.
+HTTP alternative services provide a means of indicating to clients which service
+instances a server would prefer be used for future requests.  Clients use
+alternative service advertisements as prompt to discover and use these more
+preferred service endpoints.
+
+Clients that learn about an alternative service can establish a connection to
+the identified service endpoint, which - if successfully established and
+authenticated - is then used for future requests.  Any existing connections the
+client has are retained and used until the new connection is successful.  This
+ensures that clients can continue making requests of the server without
+interruption.
 
 
-## Caching in Alternative Services
+## Previous Alternative Services Designs
 
-With RFC 7838 {{!ALT-SVC=RFC7838}}, setting the "ma" (or max-age) parameter for
-an alternative can be challenging for a server deployment.  Setting too a large
-max-age can mean that clients use an alternative for longer than they should.
-Conversely, a short cache period for an advertisement for HTTP/3 can mean that
-earlier versions might be used more often than is optimal.
+RFC 7838 {{!ALT-SVC=RFC7838}} provided the first alternative service design for
+HTTP.  This design turned out to have a number of shortcomings in deployment.
+Though these issues were anticipated in the design, the measures that were used
+often did not work particularly well.
 
-Alternative services can interact poorly with service configuration information
-that is published in the DNS.  With the introduction of HTTPS records
-{{?SVCB=I-D.ietf-dnsop-svcb-https}}, the availability of HTTP/3 can be
-advertised in the DNS, creating two independent sources of this information,
-with different approaches to caching.
+The RFC 7838 design included caching logic based on setting an "ma" (or max-age)
+parameter.  This turned out to be challenging for many server deployments.
+Setting too a large max-age meant that clients used the indicated service
+endpoint for longer than was desired when operating conditions changed.
+Conversely, a short cache period for an advertisement for HTTP/3 resulted in
+frequently reverting to earlier versions might be used more often than is
+optimal.
 
-Alternative services can also be highly dependent on networking conditions.  RFC
-7838 attempted to manage this by having clients be responsible for invalidating
-alternatives when changes in their network are detected, unless the alternative
-is explicitly marked as "persistent".  In practice, detecting the necessary
-changes is difficult for many clients, so this requirement is not consistently
-implemented.
+Alternative services turned out to interact poorly with service configuration
+information that is published in the DNS.  With the introduction of HTTPS
+records {{SVCB}}, more details of service endpoints can be advertised in the
+DNS, including the support for HTTP/3.  But this created two independent sources
+of this information, each with its own approach to caching.
 
-The alternative services mechanisms defined in RFC 7838 can produce suboptimal
-or even detrimental outcomes in some deployments.  Consequently, this document
-obsoletes RFC 7838.
+Alternative services are dependent on networking conditions.  RFC 7838 attempted
+to manage this by having clients be responsible for invalidating alternatives
+when changes in their network are detected, unless the alternative is explicitly
+marked as "persistent".  In practice, detecting the necessary changes is
+difficult for many clients, so this requirement is not consistently implemented.
+
+The result being that the alternative services mechanisms defined in RFC 7838
+produced suboptimal or even detrimental outcomes in some deployments.
+
+This document obsoletes RFC 7838.
 
 
 ## A New Alternative
@@ -148,52 +165,94 @@ connection was previously made to an alternative service.  {{reuse}} defines how
 this process works in more detail.
 
 
-## Conventions and Definitions
+## Conventions and Definitions {#terms}
 
 {::boilerplate bcp14-tagged}
+
+The terms "server" and "client" are defined in {{HTTP}}.  The term "origin" is
+defined in {{ORIGIN}}.
+
+*[server]: #terms
+*[client]: #terms
+*[origin]: #terms
+
+The term "alternative name" refers to the name advertised by a server to a
+client.  This refers to a domain name that is queried by the client to discover
+both service names and service endpoints.
+
+*[alternative name]: #terms
+*[alternative names]: #terms
+
+A "service name" is the TargetName from an HTTPS ServiceMode record {{SVCB}}.
+Service names, their associated parameters (SvcParams), and IP addresses
+describe a "service endpoint".  Clients establiish connections to service
+endpoints in order to make requests of a server.
+
+*[service name]: #terms
+*[service endpoint]: #terms
+*[service endpoints]: #terms
+
+A server is identified using its "origin name", which is the domain name from
+the target URI of resources the client makes requests toward.  This is the name
+that the client authenticates when determining if a service endpoint is
+authoritative.  Unlike an alternative name or service name, an origin name can
+be an IP address rather than a domain name.
+
+*[origin name]: #terms
+
+There can be different values for origin name, alternative name, and service
+name.
 
 
 # Using Alternative Services {#use}
 
-When a client learns about a new potential alternative from a server, they
-SHOULD attempt to use that alternative for future requests to that server.  The
-client attempts to make a request for a resource on the same server using the
-alternative as follows:
+A server advertises the availability of alternative services by providing the
+client with an alternative name.  The server does this using either a field in a
+response ({{field}}) or an HTTP/2 or HTTP/3 frame ({{frame}}).
+
+When a client receives a new alternative name from a server, they SHOULD attempt
+to discover and use the service endpoints referred to by that name for future
+requests to that server.
+
+In order to discover and use the identified service endpoints, the client
+attempts to make a request for a resource on the same server using the provided
+alternative name as follows:
 
 1. The client makes a DNS query for HTTPS records for the alternative name,
-   following the procedures in {{Section 3 of !SVCB}}.  Clients make this query
-   as a "SVCB-reliant" SVCB client, treating a failure to obtain HTTPS records
-   as a failed alternative.  If this process fails to produce service parameters
-   or IP addresses, abort this process. \[\[ISSUE: Maybe we can still be
-   SVCB-optional here, but that places constraints on the choice of name.]]
+   following the procedures in {{Section 3 of SVCB}}.  Clients make this query
+   as a "SVCB-reliant" client, treating missing or unobtainable HTTPS records as
+   a failure.  If this process fails to produce service parameters or IP
+   addresses, abort this process.
 
 2. The client establishes a connection using the service parameters and
-   addresses learned from the DNS query.  Important here is that the client uses
-   a TLS server name indication {{!SNI=RFC6066}} of the server name from the
-   URL, not the alternative name.  This allows the server to produce a
-   certificate for that name, which the client can validate as applying to the
-   URL it is resolving.  If a connection cannot be established, abort this process.
+   addresses learned from the DNS query.  The client uses the origin name in any
+   TLS server name indication {{!SNI=RFC6066}} of the server name from the URL,
+   not the alternative name.  This allows the server to produce a certificate
+   for the origin name, which the client can validate as applying to the URL it
+   is resolving.  If a connection cannot be established, abort this process.
 
-3. The client validates that the server is authoritative for the resource.  If
-   the server is not authoritative, abort this process.
+3. The client validates that the server is authoritative for the resource using
+   the server origin name.  If the server is not authoritative, abort this
+   process.
 
-4. The client makes a query for the resource.  If the server does not respond,
+4. The client makes a query for the resource.  If the server does not respond or
    responds with a 421 (Misdirected Request) (see {{Section 15.5.20 of HTTP}}),
-   or a 5xx status code (see {{Section 15.6 of HTTP}}), abort this process.
+   abort this process.  A client MAY re-attempt a request or request another
+   resource if the server responds with a 5xx status code (see {{Section 15.6 of
+   HTTP}}).
 
-5. Once a response is received, the connection to the alternative is complete.
-   Any other connections can be closed and future requests directed to the
-   alternative.  The client SHOULD remember the alternative name and the service
-   name (the TargetName from the HTTPS ServiceMode record that was used) that
-   were used; see {{remember}}.
+5. Once a response is received, the connection to the alternative service
+   endpoint is complete.  Any other connections can be closed and future
+   requests directed to the new connection.  The client SHOULD remember the
+   alternative name and the service name that were used; see {{remember}}.
 
-A client MUST NOT remember a service name for an alternative service until a
-request has been successfully completed with a 2xx or 3xx status code.  A client
-MAY send additional requests using the newly established connection to the
-alternative service after it verifies that the server is authoritative.  The
-alternative service is therefore active once the connection is established, but
-it will not be reused ({{reuse}}) for future connections until a request
-completes successfully.
+A client MAY send additional requests using the newly established connection to
+the alternative service after it verifies that the server is authoritative.
+However, a client MUST NOT remember a service name until a request has been
+successfully completed with a 2xx or 3xx status code.  The alternative service
+is therefore active once the connection is established, but it will not be
+reused ({{reuse}}) for future connections until a request completes
+successfully.
 
 A client MAY continue sending other requests over any existing connection to the
 server until this process completes in order to minimize latency for those
@@ -205,8 +264,8 @@ available for future requests with less delay.
 
 ## Retention of Alternatives {#remember}
 
-Clients SHOULD remember the successful use of an alternative service.  Two
-pieces of information are retained:
+Clients SHOULD remember the successful use of an alternative service in order to
+support reuse ({{reuse}}).  Two pieces of information are retained:
 
 * the alternative name, which is the name provided by the server in the Alt-SvcB
   field or ALTSVCB frame, and
@@ -218,62 +277,62 @@ These two names are saved for the server against the origin of the server
 {{ORIGIN}}.  Clients MUST NOT reuse saved information for a server with
 a different hostname, port, or scheme.
 
-The name given in an Alt-SvcB field or ALTSVCB frame is retained only so that
-the client can avoid initiating a connection to an alternative if it has already
-made an attempt.  Any time that a server provides a different name in an
-Alt-SvcB field or ALTSVCB frame, any existing information MUST be discarded.  A
-client MAY then initiate a DNS query and connection attempt to the identified
-alternative.  A client can subsequently ignore repeated fields or frames.
+The alternative name, as carried in an Alt-SvcB field or ALTSVCB frame, is
+retained only so that the client can avoid repeated attempts to discover and
+connect to alternative services.  A server can send Alt-SvcB fields in multiple
+responses or send multiple ALTSVCB frames.  Repeating the discovery process
+could be wasteful for a client.
 
-A server might provide an Alt-SvcB field in all responses it sends.  Only acting
-on a value once ensures that this repetition has no effect on clients.  Though a
-server might repeat the field, clients MUST NOT consider an absent field as
-indicative of a retraction of a previous advertisement.  An alternative name is
-only removed when explicitly replaced or when a remembered service name does not
-appear in the set of HTTPS query responses.
+Any time that a server provides a different name in an Alt-SvcB field or ALTSVCB
+frame, any existing information MUST be discarded.  A client MAY then initiate a
+DNS query and connection attempt using the new alternative name.
 
-On the first attempt to use an alternative, a failed alternative SHOULD be
-remembered using an alternative name and a null or absent service name.  This
-avoids making repeated attempts to use an alternative service that is not
-available if the server repeats the information in Alt-SvcB fields or ALTSVCB
-frames.  A client MAY periodically attempt to retry a failed alternative if the
-information is repeated.
+Though a server might repeat an alternative name, clients MUST NOT consider the
+absence of an Alt-SvcB field in a response as indicative of a retraction of a
+previous advertisement.  An alternative name is only removed when replaced with
+a different alternative name or when a remembered service name does not appear
+in the set of HTTPS query responses (see {{reuse}}).
+
+After a failed attempt to use an alternative service, a failure is remembered by
+retaining the alternative name without a service name.  This avoids making
+repeated attempts to use an alternative service that is not available, even if
+the server repeats the alternative name.  A client MAY periodically attempt to
+retry a failed alternative if the information is repeated.
 
 A server can explicitly request that a client remove any remembered service name
 by providing an alternative name of "invalid".  The "invalid" domain name
 corresponds to a DNS name that will never successfully resolve (see {{Section
 6.4 of ?SUDN=RFC6761}}), which guarantees that an attempt to use this name
-cannot succeed.  Clients MAY recognize the name "invalid" as special and avoid
-any attempt to use this to discover an alternative service.
+cannot succeed.  Clients MAY recognize the alternative name "invalid" as special
+and avoid any attempt to use this to discover an alternative service.
 
 
 ## Reusing Alternatives {#reuse}
 
-A client remembers the service name, or the TargetName from the ServiceMode
-HTTPS record that it successfully used to establish a connection to an
-alternative service.  In subsequent connections to the same server, it makes
-HTTP queries for the server name.  If this query returns a ServiceMode resource
-record (RR) that includes a TargetName that is identical to the remembered
-service name, the client SHOULD choose that over any alternatives, including
-those RRs that are marked "alt-only"; see {{alt-only}}.
+In subsequent connections to the same server, clients make HTTP queries for the
+origin name of the server.  If this query returns a ServiceMode resource record
+(RR) that includes a TargetName that is identical to the service name that is
+remembered for the request origin, the client SHOULD choose that over any
+alternatives.  This ignores any SvcPriority attributes that might cause other
+records to be chosen and includes any RRs that are marked "alt-only"; see
+{{alt-only}}.
 
-A client does not make a query for the remembered alternative name.  They make a
-query for the name of the server, using the QNAME derived from the URI of the
-target resource.
-
-The RR that matches the remembered service name is selected, overriding any
-SvcPriority that might otherwise result in another ServiceMode record being
-chosen.
+Note that when reusing an alternative service, a client does not make a query
+for the remembered alternative name.  HTTPS queries are made for the origin
+name, which is the domain name from the target URI of the request; see also
+{{ip}}.
 
 If a query for HTTPS records does not produce a ServiceMode record with a
-matching TargetName, any remembered information MUST be removed for that origin.
+TargetName that matches the remembered service name, all remembered information
+MUST be removed for that origin.  The client then uses the normal SVCB-optional
+resolution logic as defined in {{SVCB}}.
 
-When reusing stored information, if a connection is unsuccessful for any reason
-(see {{use}}), remembered information for that origin MUST be removed.  Clients
-clear retained alternative service information on reuse to prevent stale
-information from affecting all future connection attempts.  After removing
-remembered information, a client MAY make another attempt to connect using any
-other ServiceMode records that the DNS query produced.
+When reusing stored information, if a connection attempt is unsuccessful (see
+{{use}}), remembered information for that origin MUST be removed.  Clients clear
+retained alternative service information on reuse to prevent stale information
+from affecting all future connection attempts.  After removing remembered
+information, a client MAY make another attempt to connect using any other
+ServiceMode records that the DNS query produced.
 
 
 ### Example of Reuse
@@ -282,13 +341,13 @@ A client that is fetching "https://example.com/" might originally perform a DNS
 query for "example.com" and receive in response:
 
 ~~~ dns
-example.com.  7200 IN HTTPS 1 . port=443
-alt1.example. 7200 IN HTTPS 10 . port=8443
-alt2.example. 7200 IN HTTPS 10 . port=8443
-alt3.example. 7200 IN HTTPS 10 . port=8443
+example.com. 7200 IN HTTPS 1 . port=443
+example.com. 7200 IN HTTPS 10 alt1.example. port=8443
+example.com. 7200 IN HTTPS 10 alt2.example. port=8443
+example.com. 7200 IN HTTPS 10 alt2.example. port=8443
 ~~~
 
-Under normal conditions, the SvcPriority of the "alt?.example." RRs would indicate
+Under normal conditions, the SvcPriority of the "alt?.example" RRs would indicate
 that it is not preferred, so the "example.com" record would be used.
 
 If the client received an alternative service advertisement from this server for
@@ -296,30 +355,30 @@ If the client received an alternative service advertisement from this server for
 return a different set of records, as follows:
 
 ~~~ dns
-alt2.example. 7200 IN HTTPS 1 . port=8887
-alt3.example. 7200 IN HTTPS 1 . port=8887
+alt.example.net. 7200 IN HTTPS 1 alt2.example. port=8887 alpn=h3
+alt.example.net. 7200 IN HTTPS 1 alt3.example. port=8887 alpn=h3
 ~~~
 
-If the client selects "alt2.example." and successfully connects to that host, it
-remembers both the name given as an alternative name ("alt.example.net") and a
-service name (the TargetName from the ServiceMode HTTPS record,
-"alt2.example.").
+If the client selects "alt2.example" and successfully connects to that host, it
+remembers both the alternative name ("alt.example.net") and a service name
+("alt2.example").
 
 In subsequent connections to "example.com", the client again queries the
-"example.com" name.  Importantly, this is not any other name it might have
-learned.  The resulting response - after following indirections through
-AliasMode, CNAME, or similar mechanisms - produces the same records as previously:
+"example.com" name.  Importantly, this is the origin name and not any other name
+it might have remembered.  The resulting response - after following indirections
+through AliasMode, CNAME, or similar mechanisms - produces the same records as
+previously (perhaps because these were retained in a cache):
 
 ~~~ dns
-example.com.  7200 IN HTTPS 1 . port=443
-alt1.example. 7200 IN HTTPS 10 . port=8443
-alt2.example. 7200 IN HTTPS 10 . port=8443
-alt3.example. 7200 IN HTTPS 10 . port=8443
+example.com. 7200 IN HTTPS 1 . port=443
+example.com. 7200 IN HTTPS 10 alt1.example. port=8443
+example.com. 7200 IN HTTPS 10 alt2.example. port=8443
+example.com. 7200 IN HTTPS 10 alt2.example. port=8443
 ~~~
 
-The ServiceMode HTTPS record for "alt2.example." is used, even though this is a
+The ServiceMode HTTPS record for "alt2.example" is used, even though this is a
 lower priority than other records.  It is also used despite not using the same
-port number as previously.
+port number or protocol as the previous successful connection.
 
 
 ### Exclusive Alternative Services {#alt-only}
@@ -343,20 +402,26 @@ than "example.com", clients will not use this service unless an alternative was
 provided by the server:
 
 ~~~ dns
-alt1.example. 7200 IN HTTPS 1 . port=443,alt-only,mandatory=alt-only
+alt1.example. 7200 IN HTTPS 1 . port=443 alt-only mandatory=alt-only
 example.com.  7200 IN HTTPS 2 . port=443
 ~~~
 
-\[\[ISSUE: Do we need this flag in addition to the priority override?  Could one
-    of the two be sufficient?]]
+
+## Servers Identified by IP {#ip}
+
+An alternative name can be provided by a server that is identified by an IP
+address or host names that are not domain names.  However, HTTPS queries cannot
+be made for servers that are not identified by a domain name.  This makes reuse
+({{reuse}}) impossible for such names.  A client MAY disable alternative
+services for servers that are not identified by a domain name.
 
 
 ## Port Numbers
 
-The name that is provided in the Alt-SvcB field or ALTSVCB frame can be any
+An alternative name provided in an Alt-SvcB field or ALTSVCB frame can be any
 valid DNS QNAME.  This includes those with underscored labels
-{{?ATTRLEAF=RFC8552}}, including those that might be used to query for HTTPS
-records to a non-default port.
+{{?ATTRLEAF=RFC8552}} and those that might be used to query for HTTPS records to
+a non-default port.
 
 ~~~ http-message
 200 OK HTTP/1.1
@@ -366,16 +431,17 @@ content-length: 0
 
 ~~~
 
-This might be used to direct clients to connect to alternative ports.  Note that
-the HTTPS records might direct clients to an entirely different port number than
-the name implies.  Clients MUST NOT infer a port number from the provided name,
-instead treating this name no differently than any other.
+This might be used to direct clients to connect to alternative ports using
+existing records.  Note that the HTTPS records might direct clients to an
+entirely different port number than the name implies.  Clients MUST NOT infer a
+port number from the provided name, treating this name no differently than any
+other and using the port number derived from the service parameters.
 
 
 ## Interaction with GOAWAY
 
 Servers that advertise alternative services cannot expect clients to switch to
-the advertised alternative.  Use of the alternative is entirely at the
+the advertised alternative.  Use of any alternative is entirely at the
 discretion of clients.  If the client is unsuccessful in connecting to an
 alternative or does not attempt a connection, they could continue to use the
 existing connection for new requests.
@@ -393,61 +459,51 @@ The procedures in this document apply to clients that connect to gateways or
 reverse proxies.  However, clients that connect via a proxy, using HTTP CONNECT
 or similar methods, have a choice.
 
-Clients that provide a proxy with the name of a service leave name resolution to
-the proxy.  Such a client MUST ignore any alternative service advertisement it
-receives and MAY fallback to using legacy alternative services; see {{fallback}}.
+Clients that provide a proxy with the origin name of a server leave name
+resolution to the proxy.  Such a client MUST ignore any alternative service
+advertisement it receives.  These clients MAY fallback to using legacy
+alternative services; see {{fallback}}.
 
 Clients that make HTTPS queries for any connection attempt via a proxy can use
-alternative services.  Such a client MUST provide the proxy with the IP address
+alternative services.  Such a client can provide the proxy with the IP address
 of the server it wishes to contact, rather than providing a name.
 
 
 ## Fallback to Alt-Svc {#fallback}
 
-A client that successfully makes use of HTTPS records in resolving the name of
-an HTTP server MUST ignore any Alt-Svc fields or ALTSVC frames {{?ALT-SVC}} that
-the server provides.  This document obsoletes the mechanisms defined in RFC
-7838 {{?ALT-SVC}}.
+A client that successfully makes use of HTTPS records in resolving an origin
+name or alternative name MUST ignore any Alt-Svc fields or ALTSVC frames
+{{?ALT-SVC}} that the server provides.  This document obsoletes the mechanisms
+defined in RFC 7838 {{?ALT-SVC}}.
 
 Servers might provide Alt-Svc fields or ALTSVC frames {{?ALT-SVC}} in order to
 support clients that cannot use HTTPS records.
 
 
-## No Authority
+## Authority For Service Endpoint Configuration {#no-authority}
 
-This design does not assume that information that a client learns about
-alternatives is authoritative in any way, either by virtue of being provided by
-an authoritative server.  Instead, once a server is determined to be authorative
-(see {{Section 4.3 of HTTP}}), that server is treated as the authority on all
-aspects of service configuration.  For protocol choice, {{!ALPN=RFC7301}} and
+This design does not assume that information provided by a server or by the DNS
+is authoritative information about the configuration of service endpoints.  This
+is despite the information in Alt-SvcB fields or ALTSVCB frames being provided
+by a server that is authoritative.
+
+Instead, once a server is determined to be authorative (see {{Section 4.3 of
+HTTP}}), that server is treated as the authority on all aspects of its own
+configuration.  For example, with protocol selection, {{!ALPN=RFC7301}} and
 maybe {{?SNIP=I-D.ietf-tls-snip}} extensions in the TLS handshake
-{{!TLS=RFC8446}} determine what is used.
+{{!TLS=RFC8446}} determine what protocol is used.
 
-In contrast RFC 7838, sending alternative services over an HTTP connection
-ensures that the information is authoritative.  Clients therefore might have
-been less concerned about attacks that compromise the integrity of alternative
-services when using RFC 7838.
-
-Though integrity protection might appear to be valuable, it produced conflicts.
-For instance, information about the protocol is ostensibly authentic when
-provided in Alt-Svc fields or ALTSVC frames.  However, protocol support is also
-authenticated when establishing a connection.  This creates a potential conflict
-between two equally authoritative sources of the same information.
-
-Conflicts also arise when alternative service information is retained as any
-retained state might disagree with what is currently deployed.  This design
-avoids this contention by having the entire service resolution process occur
-almost entirely to the DNS.
-
-An alternative service advertisement provides only a minimal nudge to perform a
-DNS query at the time it is made.  On reconnection, remembered state only
-affects prioritization of active DNS records.  Invalid configurations do not
-persist.
+For requests, a server that is determined to be authoritative for an origin can
+answer all requests on that origin.  All service endpoints that are
+authoritative SHOULD provide equivalent service to any other, though they could
+differ in terms of performance, diagnostic information, or other minor details.
+Clients will expect service endpoints to provide equivalent - or perhaps
+identical - service.
 
 
 # Protocol Elements
 
-Multiple ways of encoding an alternative service name is defined.  The Alt-SvcB
+Multiple ways of advertising alternative services are defined.  The Alt-SvcB
 field in {{field}} allows servers to indicate a preferred service in responses.
 The ALTSVCB frames in {{frame}} allows a server to provide alternative names
 outside of the context of a query.
@@ -474,17 +530,17 @@ period character (".", U+2E).  Each value MAY end with a period, though - for
 the purposes of the process in {{use}} - the string is treated as an absolute
 DNS QNAME whether or not a trailing period is present.
 
-The applicable origin {{ORIGIN}} is derived from the origin of the Target
-Resource (see {{Section 7.1 of HTTP}}).
+The applicable origin is derived from the origin of the target URI; see
+{{Section 7.1 of HTTP}} and {{ORIGIN}}.
 
 If multiple Alt-SvcB fields or field values are present in a response, the
 client MAY use any subset of the provided alternative names, including none,
 one, or all of the provided names.
 
 Servers SHOULD NOT provide more than one name.  The DNS provides ample
-opportunity to present clients with options, including the use of priority to
-help manage selection.  A list is tolerated only to allow for the possibility
-that multiple field lines might be added to responses without proper
+opportunity to present clients with multiple options, including the use of
+priority to help manage selection.  A list is tolerated only to allow for the
+possibility that multiple field lines might be added to responses without proper
 coordination.
 
 Clients MUST ignore unknown parameters that are provided with alternative names.
@@ -536,14 +592,101 @@ ignore any frames other than the most recent.
 
 # Security Considerations {#security}
 
-TODO Lots of work to do here.  Review RFC 7838 for relevant information to copy over.
+Alternative services present servers with a way of influencing how clients
+select service endpoints.  This does not change how a service endpoint might be
+determined to be authoritative (even more so than its predecessor; see
+{{authority7838}}), but this.
+
+
+## Selecting Service Endpoints {#sec-endpoint}
+
+This design assumes a Dolev-Yao attacker as is typical for Internet protocols
+{{?RFC3552}}.  This model assumes that an attacker has complete control of the
+network.
+
+This design only supports HTTPS.  Cleartext HTTP, such as might be used for URIs
+with a scheme of "http", is not supported.  This means that TLS {{!TLS=RFC8446}}
+is always used to establish whether a service endpoint is authoritative,
+according to {{Section 4.3.3 of HTTP}}.  TLS protects the configuration of
+service endpoints, including the choice of protocol; see {{no-authority}}.
+Furthermore, TLS prevents an attacker from inspecting or modifying the content
+of connections.
+
+Even with TLS, a client connects to a service endpoint of the attacker's choice.
+This is a property of HTTP that the use of alternative services does not change,
+as the choice of service endpoint (including IP address and port number) is not
+authenticated when establishing a connection.
+
+Certificates used to establish authority for HTTP servers do not include a port
+number, which means that all HTTP services that have a certificate for the same
+name will be treated by clients as being potentially authoritative.  {{Section
+4.3.3 of HTTP}} mandates checks on the target URI to mitigate this attack.
+Servers can use a 421 (Misdirected Request) status code (see {{Section 15.5.20
+of HTTP}}) to signal any error and avoid the service endpoint being used.
+
+DNS is not assumed to be secure in this threat model.  The use of DNSSEC
+{{?DNSSEC=RFC4033}} can ensure that clients do not receive incorrect information
+from DNS queries.  However, DNSSEC does not defend against attacks on routing or
+forwarding infrastructure that might result in connections being directed toward
+a service endpoint chosen by an attacker.  Using DNSSEC therefore does not
+change this analysis, though it can make attacks less feasible for some classes
+of attacker and so use is encouraged.
+
+
+## Attacks From Within Servers
+
+In addition to network-based attackers, we also consider the possibility that an
+alternative service is advertised by an adversary who is able to generate HTTP
+responses.  An adversary might be given the ability to generate responses for a
+subset of the resources on a server, where they might provide an Alt-SvcB field
+in a response.
+
+This gives such an adversary some ability to direct clients toward a service
+endpoint of their choosing; see {{sec-endpoint}}.  It also potentially allows an
+adversary to create an unending sequence of alternatives; see {{sec-loop}}.
+
+Servers can mitigate these risks by restricting access to the ability of
+advertising an alternative name.
+
+
+## Tracking Clients
+
+Remembering alternative names and service names might allow a server to connect
+activity at different times to the same client.  Clients might be assigned a
+unique alternative name and service name in order to make return connections
+identifiable.  The need for the service name to appears the set of HTTPS records
+at the origin name does limit the ability of servers to individual track clients
+at scale, but this still might be used to separate clients into groups for
+tracking purposes or to track specific individuals.
+
+Clients that clear origin-specific state in order to manage the risk of tracking
+MUST remove any remembered alternative service information when clearing state
+for a server (typically, this is associated with clearing cookies {{?RFC6265}}).
+
+
+## Multiple Alternatives in Sequence {#sec-loop}
+
+A client might receive multiple different alternative names in sequence, causing
+it to spend additional resources in discovering and connecting to different
+service endpoints.  Repeatedly making connections can adversely affect
+performance.
+
+This might be caused by a loop where the alternative name
+provided by each service endpoint points to the other or simply an unending
+sequence of new alternative names.  This can arise if service endpoints are
+poorly configured.
+
+A client can limit the effect of such misconfiguration by ignoring alternative
+names that change too frequently.  A client might then continue to use the
+service endpoint to which it is connected or disable alternative services
+entirely for that origin.
 
 
 # Internationalization Considerations {#i18n}
 
 An internationalized domain name that appears in either an Alt-SvcB field
 ({{field}}) or an ALTSVCB frame ({{frame}}) MUST be expressed using A-labels;
-see {{Section 2.3.2.1 of !RFC5890}}.
+see {{Section 2.3.2.1 of !RFC5890}}.
 
 
 # IANA Considerations {#iana}
@@ -558,6 +701,30 @@ TODO register:
 
 --- back
 
+# Authoritative Information in RFC 7838 {#authority7838}
+
+This design differs from RFC 7838, where alternative services advertisements
+were treated as authoritative information.  Clients therefore might have been
+less concerned about attacks that compromise the integrity of alternative
+services when using RFC 7838.
+
+Though integrity protection might appear to be valuable, it results in
+conflicts.  For instance, information about the protocol is ostensibly authentic
+when provided in Alt-Svc fields or ALTSVC frames.  However, protocol support is
+also authenticated when establishing a connection.  This creates a potential
+conflict between two sources of the same information.
+
+Conflicts also arise when alternative service information is retained as any
+retained state might disagree with what is currently deployed.  This design
+avoids this contention by having the entire service resolution process occur
+almost entirely to the DNS.
+
+This design provides clients with a prompt to discover a new service endpoint.
+On subsequent connections, remembered state only affects prioritization of
+active DNS records.  Service endpoints are always authoritative for their own
+configuration.  Invalid configurations therefore do not persist.
+
+
 # Contributors
 {:numbered="false"}
 
@@ -569,7 +736,7 @@ ideas.
 {:numbered="false"}
 
 This work is input to discussions with a design team on HTTP alternative
-services, formed after realizing that a simple revision to RFC 7838.  Though it
-is informed by discussions thus far, it is NOT the product of that group.
-Thanks are due to those who have participated in those discussions, who the
-author is to cowardly to list due to the risk that someone is missed.
+services, formed after realizing that a simple revision to RFC 7838 would not
+fix known problems.  Thanks are due to Ryan Hamilton, Tommy Pauly, and Matthew
+Stock for their contributions to these discussions.  David Schinazi also
+provided valuable input.

--- a/draft-thomson-httpbis-alt-svcb.md
+++ b/draft-thomson-httpbis-alt-svcb.md
@@ -348,7 +348,7 @@ example.com. 7200 IN HTTPS 10 alt2.example. port=8443
 ~~~
 
 Under normal conditions, the SvcPriority of the "alt?.example" RRs would indicate
-that it is not preferred, so the "example.com" record would be used.
+that they are not preferred, so the "example.com" record would be used.
 
 If the client received an alternative service advertisement from this server for
 "alt.example.net" it would then make a DNS query to that name.  This might

--- a/draft-thomson-httpbis-alt-svcb.md
+++ b/draft-thomson-httpbis-alt-svcb.md
@@ -411,8 +411,8 @@ example.com.  7200 IN HTTPS 2 . port=443
 
 An alternative name can be provided by a server that is identified by an IP
 address or host names that are not domain names.  However, HTTPS queries cannot
-be made for servers that are not identified by a domain name.  This makes reuse
-({{reuse}}) impossible for such names.  A client MAY disable alternative
+be made for servers that are not identified by a domain name.  This makes it
+impossible to use such identifiers.  A client MAY disable alternative
 services for servers that are not identified by a domain name.
 
 

--- a/draft-thomson-httpbis-alt-svcb.md
+++ b/draft-thomson-httpbis-alt-svcb.md
@@ -73,8 +73,8 @@ physical servers, the need to place endpoints in network locations that are
 closer to clients for performance reasons, or the need to support multiple HTTP
 versions, like HTTP/2 {{H2}} or HTTP/3 {{H3}}.
 
-For servers that operate multiple service endpoints, it can be advantageous - or
-even necessary - to have clients make requests to a specific service endpoint.
+For servers that operate multiple service endpoints, it can be advantageous to
+have clients make requests to a specific service endpoint.
 
 * Some deployments might seek to direct a client to a service endpoint that is
   better able to serve requests for that client.  This might occur if DNS

--- a/draft-thomson-httpbis-alt-svcb.md
+++ b/draft-thomson-httpbis-alt-svcb.md
@@ -595,7 +595,7 @@ ignore any frames other than the most recent.
 Alternative services present servers with a way of influencing how clients
 select service endpoints.  This does not change how a service endpoint might be
 determined to be authoritative (even more so than its predecessor; see
-{{authority7838}}), but this.
+{{authority7838}}).
 
 
 ## Selecting Service Endpoints {#sec-endpoint}


### PR DESCRIPTION
The first version was done in a bit of a rush.  This is the result of a comprehensive re-read.  It includes:

* An abstract.  Closes #4.
* Crisper terminology.  Closes #18.
* HTTP/3 in an example.  Closes #19.
* Text on IP addresses.  Closes #6.
* Tweaks to proxy language.  This is for #17, but I want to continue that discussion some more before closing it out.
* Security considerations:
  * A threat model that covers switching between service endpoints. Closes #3.
  * Explicit mention that this is only HTTPS.  Closes #1.
  * Service instances are supposed to be the same.  Closes #8.
  * Language on insider attacks, inspired by and borrowing from RFC 7838.
  * Text on looping and indefinite series of new alternatives, which is new as far as I know.  Closes #20.
  * Text on tracking, copying again from RFC 7838.  Closes #2.
* Editorial fixes throughout.

It's a big changeset and probably imperfect.  I also know that people are busy, but I'd like to get this in, using new issues to track pieces where I messed up.  Unless there is something truly terrible, of course.